### PR TITLE
Synchronise stream volume with app volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Rdio for Nuvola Player 3
 
 Integration of Rdio into your linux desktop via
 [Nuvola Player](https://github.com/tiliado/nuvolaplayer).
- 
+
 Support
 -------
 
@@ -19,6 +19,7 @@ Installation
 
 Copyright
 ---------
+  - Copyright 2015 Jordan Klassen <forivall@gmail.com>
   - Copyright 2015 Aaron Cripps <acripps@gmail.com>
   - Copyright 2014 Jiří Janoušek <janousek.jiri@gmail.com>
   - Copyright 2014 Martin Pöhlmann <martin.deimos@gmx.de>

--- a/integrate.js
+++ b/integrate.js
@@ -3,6 +3,7 @@
  * Copyright 2014 Martin Pöhlmann <martin.deimos@gmx.de>
  * Copyright 2014 Jiří Janoušek <janousek.jiri@gmail.com>
  * Copyright 2015 Aaron Cripps <acripps@gmail.com>
+ * Copyright 2015 Jordan Klassen <forivall@gmail.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -75,7 +76,7 @@
 		}
 
 		var state = PlaybackState.UNKNOWN;
-		
+
 		try
 		{
 			var playingTrack = R.Services.Player.model.get("playingTrack").attributes;

--- a/integrate.js
+++ b/integrate.js
@@ -116,6 +116,23 @@
 		player.setCanPlay(canPlay);
 		player.setCanPause(canPause);
 
+		// synchronise stream volume with app volume
+		if (state == PlaybackState.PLAYING) {
+			try {
+				var playerVolume = R.Services.Player.volume();
+				var streamVolume = R.Services.Player._audio._element.volume;
+				if (streamVolume != null) {
+					streamVolume = Math.sqrt(streamVolume);
+					if (Math.abs(streamVolume - playerVolume) >= 0.01) {
+						R.Services.Player.volume(streamVolume);
+					}
+				}
+			}
+			catch (e) {
+				// do nothing
+			}
+		}
+
 		// Schedule the next update
 		setTimeout(this.update.bind(this), 500);
 	}


### PR DESCRIPTION
Rdio does not update their volume slider when the stream's volume 
changes, since most platforms cannot change the volume externally. 
With pulseaudio and gtkwebkit, the volume can be changed externally, 
so this will update the slider position when the stream volume is 
changed by pulseaudio.  

Implementation notes: Accesses internal Rdio app data, so this may 
break in the future. If this stops working, it will safely degrade and 
not affect the rest of the integration.
- Author: Jordan Klassen forivall@gmail.com
- Reviewed by: Jiří Janoušek janousel.jiri@gmail.com
- Reviewed by: FIXME <FIXME>
- Issue: tiliado/nuvola-app-rdio#2
- Pull Request: tiliado/nuvola-app-rdio#3
